### PR TITLE
more examples link no longer 404's

### DIFF
--- a/example-code/c.md
+++ b/example-code/c.md
@@ -47,5 +47,5 @@ namespace htciExample
 
 ## More examples  <a id="more-examples"></a>
 
-For more advanced examples, [take a look here](https://github.com/htmlcsstoimage/docs/tree/f2267eac0924af42a670353de74fc9c83b6385b6/~/drafts/-LPHcAPUeRw0IdlUIJu2/primary/README.md#examples).
+For more advanced examples, [take a look here](https://github.com/htmlcsstoimage/docs/blob/master/README.md#examples).
 


### PR DESCRIPTION
current link points to somewhere that no longer exists on github