### PR TITLE
Jumbo Docs & Cleanup

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -92,7 +92,7 @@ aux_links:
   "Get an API Key":
     - "https://htmlcsstoimage.com"
   "Demo":
-    - "https://htmlcsstoimage.com/demo"
+    - "https://htmlcsstoimage.com/#demo"
 
 # Exclude from processing.
 # The following items will not be processed, by default.

--- a/_includes/additional_parameters.md
+++ b/_includes/additional_parameters.md
@@ -10,6 +10,9 @@
 | **block_consent_banners**   | `Boolean` | When set to `true`, automatically blocks cookie consent banners and popups on websites. Most useful for URL screenshots. [Learn more](/guides/advanced/blocking-cookie-banners/). |
 | **viewport_width**   | `Integer` | Set the width of Chrome's viewport. This will disable automatic cropping. Both height and width parameters must be set if using either. [Learn more](/getting-started/setting-height-and-width/). |
 | **viewport_height**   | `Integer` | Set the height of Chrome's viewport. This will disable automatic cropping. Both height and width parameters must be set if using either. [Learn more](/getting-started/setting-height-and-width/). |
+| **viewport_mobile** | `Boolean` | Set Chrome's viewport to emulate a mobile device. |
+| **viewport_landscape**| `Boolean` | Set Chrome's viewport to landscape mode. |
+| **viewport_touch** | `Boolean` | Set Chrome's viewport to support touch events. |
 | **color_scheme**   | `String` | Set Chrome to render in `light` or `dark` mode. Affects websites using `prefers-color-scheme`. [Learn more](/parameters/color_scheme/). |
 | **timezone**   | `String` | Render your image with Chrome set to a specified timezone. Use IANA timezone identifiers like `America/New_York`. [Learn more](/parameters/timezone/). |
 | **disable_twemoji**   | `Boolean` | Twemoji is used by default to render emoji consistently. Set to `true` to use native emoji fonts instead. |

--- a/_includes/additional_parameters.md
+++ b/_includes/additional_parameters.md
@@ -14,3 +14,5 @@
 | **timezone**   | `String` | Render your image with Chrome set to a specified timezone. Use IANA timezone identifiers like `America/New_York`. [Learn more](/parameters/timezone/). |
 | **disable_twemoji**   | `Boolean` | Twemoji is used by default to render emoji consistently. Set to `true` to use native emoji fonts instead. |
 | **proxy_id**   | `String` | Route the render's outbound traffic through one of your [HTTP proxies](/guides/advanced/proxies/) configured in the dashboard. Available on the 10k images/month plan or higher. |
+| **jumbo_max_width**   | `Integer` | Maximum output width when rendering a [jumbo image](/guides/advanced/jumbo-images/) (up to 80,000px). Must be set together with `jumbo_max_height`. Consumes extra renders. |
+| **jumbo_max_height**   | `Integer` | Maximum output height when rendering a [jumbo image](/guides/advanced/jumbo-images/) (up to 80,000px). Must be set together with `jumbo_max_width`. Consumes extra renders. |

--- a/_includes/intro.md
+++ b/_includes/intro.md
@@ -5,7 +5,7 @@
 Generate a png, jpg or webp images with {{ include.language }}. Renders exactly like Google Chrome.
 {: .fs-6 .fw-300 }
 
-[Live demo](https://htmlcsstoimage.com/demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 target="_blank" }
+[Live demo](https://htmlcsstoimage.com/#demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 target="_blank" }
 [Get an API Key](https://htmlcsstoimage.com){: .btn .fs-5 .mb-4 .mb-md-0 target="_blank" }
 <hr>
 

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -335,7 +335,7 @@ img {
 .content-with-toc > .main-content {
   flex: 1;
   min-width: 0;
-  max-width: 750px;
+  
   
   @media (max-width: 800px) {
     max-width: 100%;

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -314,7 +314,7 @@ img {
 
 @media (min-width: 1200px) {
   .main {
-    max-width: none !important;
+    max-width: 1200px !important;
   }
   
   .main-content-wrap {

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -20,6 +20,7 @@
 }
 
 .main {
+  flex-grow: 1;
   @include mq(md) {
     position: relative;
     max-width: $content-width;

--- a/changelog.md
+++ b/changelog.md
@@ -366,7 +366,7 @@ August 16, 2020
 We've rebuilt the live demo. Now you can preview your HTML/CSS as you edit it. Then click the *image* button to see it converted into an image.
 This makes it much easier to prototype your images inside a browser.
 
-- [HTML/CSS to Image Demo](https://htmlcsstoimage.com/demo)
+- [HTML/CSS to Image Demo](https://htmlcsstoimage.com/#demo)
 
 <hr>
 ### Ruby Client released

--- a/example-code/c.md
+++ b/example-code/c.md
@@ -14,7 +14,7 @@ description: >-
 Generate png, jpg or webp images with C# and .NET. Renders exactly like Google Chrome.
 {: .fs-6 .fw-300 }
 
-[Live demo](https://htmlcsstoimage.com/demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 target="_blank" }
+[Live demo](https://htmlcsstoimage.com/#demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 target="_blank" }
 [Get an API Key](https://htmlcsstoimage.com){: .btn .fs-5 .mb-4 .mb-md-0 target="_blank" }
 <hr>
 

--- a/example-code/curl.md
+++ b/example-code/curl.md
@@ -14,7 +14,7 @@ description: >-
 Generate a png, jpg or webp images from your terminal with cURL.
 {: .fs-4 .fw-300 }
 
-[Live demo](https://htmlcsstoimage.com/demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 target="_blank" }
+[Live demo](https://htmlcsstoimage.com/#demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 target="_blank" }
 [Get an API Key](https://htmlcsstoimage.com){: .btn .fs-5 .mb-4 .mb-md-0 target="_blank" }
 <hr>
 

--- a/example-code/google-apps-script.md
+++ b/example-code/google-apps-script.md
@@ -14,7 +14,7 @@ description: >-
 Generate a png, jpg or webp images with Google Apps Script.
 {: .fs-4 .fw-300 }
 
-[Live demo](https://htmlcsstoimage.com/demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 target="_blank" }
+[Live demo](https://htmlcsstoimage.com/#demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 target="_blank" }
 [Get an API Key](https://htmlcsstoimage.com){: .btn .fs-5 .mb-4 .mb-md-0 target="_blank" }
 <hr>
 

--- a/example-code/index.md
+++ b/example-code/index.md
@@ -14,7 +14,7 @@ description: >-
 To get started quickly, take a look at our example code for generating images.
 {: .fs-4 .fw-300 }
 
-[Live demo](https://htmlcsstoimage.com/demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Live demo](https://htmlcsstoimage.com/#demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [Get an API Key](https://htmlcsstoimage.com){: .btn .fs-5 .mb-4 .mb-md-0 }
 
 {% include hint.md title="Using an AI coding assistant?" text="Skip writing code entirely. Connect our [MCP Server](/integrations/mcp/) to generate images directly from Cursor or Claude Code." %}

--- a/example-code/ruby.md
+++ b/example-code/ruby.md
@@ -14,7 +14,7 @@ description: >-
 Generate a png, jpg or webp images with Ruby. Renders exactly like Google Chrome.
 {: .fs-6 .fw-300 }
 
-[Live demo](https://htmlcsstoimage.com/demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 target="_blank" }
+[Live demo](https://htmlcsstoimage.com/#demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 target="_blank" }
 [Get an API Key](https://htmlcsstoimage.com){: .btn .fs-5 .mb-4 .mb-md-0 target="_blank" }
 <hr>
 

--- a/example-code/vb.net.md
+++ b/example-code/vb.net.md
@@ -14,7 +14,7 @@ description: >-
 Generate a png, jpg or webp images from your terminal with VB.NET
 {: .fs-4 .fw-300 }
 
-[Live demo](https://htmlcsstoimage.com/demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 target="_blank" }
+[Live demo](https://htmlcsstoimage.com/#demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 target="_blank" }
 [Get an API Key](https://htmlcsstoimage.com){: .btn .fs-5 .mb-4 .mb-md-0 target="_blank" }
 <hr>
 

--- a/getting-started/height-and-width.md
+++ b/getting-started/height-and-width.md
@@ -131,4 +131,8 @@ Once you have determined your height and width in pixels, you can then set your 
 If you need the DPI metadata tag set on your image, you can do this by adding the query param to your image url. For example `hcti.io/v1/image/123abc?dpi=300`.
 Please note, you will still need to use the calculations above to create an image large enough to have the correct DPI when printed.
 
+### Jumbo Images
+
+If you need to render really large images without sacrificing quality, you'll want to set the `jumbo_max_width` and `jumbo_max_height` parameters. [Learn more](/guides/advanced/jumbo-images).
+
 {% include code_footer.md version=3 %}

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -15,7 +15,7 @@ description: >-
 Start here to learn how to use the HTML/CSS to Image API.
 {: .fs-6 .fw-300 }
 
-[Live demo](https://htmlcsstoimage.com/demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Live demo](https://htmlcsstoimage.com/#demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [Get an API Key](https://htmlcsstoimage.com){: .btn .fs-5 .mb-4 .mb-md-0 }
 
 <hr>

--- a/getting-started/templates.md
+++ b/getting-started/templates.md
@@ -101,9 +101,15 @@ Optional parameters for greater control over your image.
 | **render_when_ready**   | `Boolean` | Set to true to control when the image is generated. Call `ScreenshotReady()` from JavaScript to generate the image. [Learn more](/parameters/render_when_ready/). |
 | **viewport_width**   | `Integer` | Set the width of Chrome's viewport. This will disable automatic cropping. Both height and width parameters must be set if using either. |
 | **viewport_height**   | `Integer` | Set the height of Chrome's viewport. This will disable automatic cropping. Both height and width parameters must be set if using either. |
+| **viewport_mobile** | `Boolean` | Set Chrome's viewport to emulate a mobile device. |
+| **viewport_landscape**| `Boolean` | Set Chrome's viewport to landscape mode. |
+| **viewport_touch** | `Boolean` | Set Chrome's viewport to support touch events. |
 | **color_scheme**   | `String` | Set Chrome to render in `light` or `dark` mode. [Learn more](/parameters/color_scheme/). |
 | **timezone**   | `String` | Render your image with Chrome set to a specified timezone. Use IANA timezone identifiers. [Learn more](/parameters/timezone/). |
 | **disable_twemoji**   | `Boolean` | Set to `true` to use native emoji fonts instead of Twemoji. |
+| **proxy_id**   | `String` | Route the render's outbound traffic through one of your [HTTP proxies](/guides/advanced/proxies/) configured in the dashboard. Available on the 10k images/month plan or higher. |
+| **jumbo_max_width**   | `Integer` | Maximum output width when rendering a [jumbo image](/guides/advanced/jumbo-images/) (up to 80,000px). Must be set together with `jumbo_max_height`. Consumes extra renders. |
+| **jumbo_max_height**   | `Integer` | Maximum output height when rendering a [jumbo image](/guides/advanced/jumbo-images/) (up to 80,000px). Must be set together with `jumbo_max_width`. Consumes extra renders. |
 
 <hr>
 
@@ -181,9 +187,15 @@ Optional parameters for greater control over your image.
 | **render_when_ready**   | `Boolean` | Set to true to control when the image is generated. Call `ScreenshotReady()` from JavaScript to generate the image. [Learn more](/parameters/render_when_ready/). |
 | **viewport_width**   | `Integer` | Set the width of Chrome's viewport. This will disable automatic cropping. Both height and width parameters must be set if using either. |
 | **viewport_height**   | `Integer` | Set the height of Chrome's viewport. This will disable automatic cropping. Both height and width parameters must be set if using either. |
+| **viewport_mobile** | `Boolean` | Set Chrome's viewport to emulate a mobile device. |
+| **viewport_landscape**| `Boolean` | Set Chrome's viewport to landscape mode. |
+| **viewport_touch** | `Boolean` | Set Chrome's viewport to support touch events. |
 | **color_scheme**   | `String` | Set Chrome to render in `light` or `dark` mode. [Learn more](/parameters/color_scheme/). |
 | **timezone**   | `String` | Render your image with Chrome set to a specified timezone. Use IANA timezone identifiers. [Learn more](/parameters/timezone/). |
 | **disable_twemoji**   | `Boolean` | Set to `true` to use native emoji fonts instead of Twemoji. |
+| **proxy_id**   | `String` | Route the render's outbound traffic through one of your [HTTP proxies](/guides/advanced/proxies/) configured in the dashboard. Available on the 10k images/month plan or higher. |
+| **jumbo_max_width**   | `Integer` | Maximum output width when rendering a [jumbo image](/guides/advanced/jumbo-images/) (up to 80,000px). Must be set together with `jumbo_max_height`. Consumes extra renders. |
+| **jumbo_max_height**   | `Integer` | Maximum output height when rendering a [jumbo image](/guides/advanced/jumbo-images/) (up to 80,000px). Must be set together with `jumbo_max_width`. Consumes extra renders. |
 
 <hr>
 
@@ -295,7 +307,7 @@ STATUS: 200 OK
       "updated_at": "2020-07-19T17:16:43.987+00:00",
       "version": 1595179003987,
       "viewport_height": null,
-      "viewport_width": null
+      "viewport_width": null,      
     }
   ],
   "pagination": {

--- a/getting-started/using-the-api.md
+++ b/getting-started/using-the-api.md
@@ -14,7 +14,7 @@ description: >-
 Generate images from HTML and CSS.
 {: .fs-6 .fw-300 }
 
-[Live demo](https://htmlcsstoimage.com/demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Live demo](https://htmlcsstoimage.com/#demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [Get an API Key](https://htmlcsstoimage.com){: .btn .fs-5 .mb-4 .mb-md-0 }
 
 {% include hint.md title="Using Cursor or Claude Code?" text="Generate images without writing code using our [MCP Server integration](/integrations/mcp/)." %}

--- a/guides/advanced/index.md
+++ b/guides/advanced/index.md
@@ -24,5 +24,6 @@ Get more from the API.
 | [Account Usage](/guides/advanced/account-usage/) | Track your API usage programmatically |
 | [Base64 to Image](/guides/advanced/base64/) | Work with Base64-encoded images |
 | [HTTP Proxies](/guides/advanced/proxies/) | Route renders through your own HTTP proxy |
+| [Jumbo Images](/guides/advanced/jumbo-images/) | Render images larger than 8000px by splitting into tiles |
 
 

--- a/guides/advanced/jumbo-images.md
+++ b/guides/advanced/jumbo-images.md
@@ -27,7 +27,7 @@ Render large screenshots without reducing quality by splitting and stitching til
 
 Rendering really tall or wide html with Puppeteer has issues around <a href="https://github.com/puppeteer/puppeteer/issues/1576" target="_blank">8000px</a> where your content may start repeating or overlapping. Most images don't reach these extremes, and when they do - we'll scale down your image to fit and prevent this behavior.
 
-Jumbo images get around this. When you set `jumbo_max_width` and `jumbo_max_height`, the API renders your output in **8000 x 8000 tiles** and stitches them back into a single image. This lets you generate images up to **80,000 pixels** on a side.
+Jumbo images allow you to scale beyond this. When you set `jumbo_max_width` and `jumbo_max_height`, the API renders lets you generate images up to **80,000 pixels** on a side.
 
 ### Why jumbo matters
 

--- a/guides/advanced/jumbo-images.md
+++ b/guides/advanced/jumbo-images.md
@@ -1,0 +1,232 @@
+---
+layout: page
+title: Jumbo Images
+permalink: /guides/advanced/jumbo-images/
+parent: Advanced
+grand_parent: Guides
+nav_order: 6
+description: >-
+  Render images larger than 8000px by splitting into tiles and stitching them together. Includes parameter limits and billing details.
+---
+
+# Jumbo Images
+{: .no_toc }
+{: .fs-9 }
+
+Render images larger than the standard ~8000px limit by splitting and stitching tiles.
+{: .fs-6 .fw-300 }
+
+<hr>
+
+1. TOC
+{:toc}
+
+<hr>
+
+## What are jumbo images?
+
+Standard renders are capped at roughly **8000 pixels** on each side. That's a Chrome rendering limit, not an API one — once you cross it, the browser starts dropping content or refusing to paint.
+
+Jumbo images get around this. When you set `jumbo_max_width` and `jumbo_max_height`, the API renders your output in **8000 x 8000 tiles** and stitches them back into a single image. This lets you generate images up to **80,000 pixels** on a side.
+
+### Why jumbo matters
+
+The big win is **quality**. Jumbo lets you produce huge images **without losing sharpness**:
+
+- Your `device_scale` is preserved end-to-end. A `2x` retina render stays `2x` — even at 50,000 pixels wide.
+- Each tile is rendered natively in Chrome at full resolution, then stitched. There's no resampling or post-render shrinking.
+- Crisp text, vector edges, and 1px borders that would normally turn fuzzy on huge canvases stay clean.
+
+{% include hint.md title="Without jumbo, large images get downscaled" text="If your output would naturally exceed ~8000px and you **don't** set the jumbo params, the API automatically scales the image down to fit Chrome's limit. That usually shows up as a **blurry, lower-resolution image** — text gets soft, fine lines smear, and high `device_scale` values stop helping. If your render is anywhere near 8000px on either side, set `jumbo_max_width` and `jumbo_max_height` to keep it sharp." %}
+
+### When to use it
+
+- Long marketing pages, full-site captures, or scrollable dashboards.
+- Print-resolution posters, signage, or banners.
+- Wide infographics, timelines, charts, or data tables.
+- Retina (`device_scale: 2` or `3`) renders of medium-sized pages where `width * device_scale` would already cross 8000px.
+- Any HTML or URL screenshot where the natural output exceeds ~8000px.
+
+Jumbo works with both `html`/`css` and `url` requests.
+
+<hr>
+
+## Parameters
+
+| Parameter | Type | Description |
+|:----------|:-----|:------------|
+| `jumbo_max_width` | `Integer` | Maximum output width, in pixels. Range: `1` – `80000`. **Required** when `jumbo_max_height` is set. |
+| `jumbo_max_height` | `Integer` | Maximum output height, in pixels. Range: `1` – `80000`. **Required** when `jumbo_max_width` is set. |
+
+Both parameters must be set together. Setting one without the other returns a `400`.
+
+These are **maximums**, not exact dimensions. If your content is smaller than the max, you get a smaller image. If it's larger, the renderer scales down to fit (see [How it works](#how-it-works)).
+
+<hr>
+
+## How it works
+
+When you pass `jumbo_max_width` and `jumbo_max_height`, the renderer:
+
+1. Measures the natural size of your page (or `selector` element) at the requested `device_scale`.
+2. If that natural size fits inside `jumbo_max_width` x `jumbo_max_height`, it renders at full resolution.
+3. If it doesn't fit, it picks the largest scale that **preserves the aspect ratio** and stays inside both maxes.
+4. Splits the output into **8000 x 8000 tiles**.
+5. Renders each tile separately in Chrome.
+6. Stitches the tiles back into a single image and uploads the result.
+
+```mermaid
+flowchart LR
+    Request[Request with jumbo_max] --> Measure[Measure natural size]
+    Measure --> Fits{Fits in max?}
+    Fits -->|Yes| FullScale[Render at full scale]
+    Fits -->|No| Downscale[Downscale, preserve aspect ratio]
+    FullScale --> Split[Split into 8000x8000 tiles]
+    Downscale --> Split
+    Split --> RenderTiles[Render each tile]
+    RenderTiles --> Stitch[Stitch tiles together]
+    Stitch --> Upload[Upload final image]
+```
+
+The result is a single image — you don't need to do any stitching on your end.
+
+<hr>
+
+## Limits
+
+| Rule | Limit |
+|:-----|:------|
+| Max value per dimension | `80,000` pixels |
+| Min value per dimension | `1` pixel |
+| At least one dimension must exceed | `8,000` pixels |
+| Max total area (`width * height`) | `400,000,000` pixels |
+| Both parameters must be set | Yes — sending one alone returns `400` |
+| Compatible with `pdf_options` | No — jumbo is image-only |
+
+The "at least one dimension must exceed 8,000" rule exists because anything smaller fits in a single tile and should use a normal render instead.
+
+The 400-million-pixel area cap means you can't max out both dimensions at once. Some valid combinations at the limit:
+
+- `80,000 x 5,000`
+- `40,000 x 10,000`
+- `20,000 x 20,000`
+- `12,500 x 32,000`
+
+<hr>
+
+## Billing
+
+Jumbo images consume **one render per tile**, deducted from your monthly quota.
+
+The number of tiles is calculated from the **final output size** (after any aspect-ratio downscaling):
+
+```
+tiles = ceil(output_width / 8000) * ceil(output_height / 8000)
+```
+
+If you also use `ms_delay`, the standard delay cost is added on top of the tile count:
+
+```
+total_renders = tiles + ceil(ms_delay / 5000)   # when ms_delay > 0
+```
+
+### Examples
+
+| Output size | `ms_delay` | Renders billed |
+|:------------|:-----------|:---------------|
+| `8,001 x 8,001` | 0 | 4 |
+| `12,000 x 8,100` | 0 | 2 |
+| `16,000 x 16,000` | 0 | 4 |
+| `24,000 x 16,000` | 0 | 6 |
+| `80,000 x 5,000` | 0 | 10 |
+| `16,000 x 16,000` | `7000` | 6 (4 tiles + 2 delay) |
+
+{% include hint.md title="Tip" text="Set `jumbo_max_width` and `jumbo_max_height` only as large as you actually need. The render count grows quickly — doubling both dimensions roughly quadruples the cost." %}
+
+<hr>
+
+## Examples
+
+### HTML render
+
+```json
+{
+  "html": "<div style='width:12000px;height:8100px;background:linear-gradient(45deg,#4f46e5,#ec4899);'></div>",
+  "jumbo_max_width": 12000,
+  "jumbo_max_height": 8100
+}
+```
+
+### URL render
+
+```json
+{
+  "url": "https://example.com/long-marketing-page",
+  "jumbo_max_width": 2000,
+  "jumbo_max_height": 30000,
+  "full_screen": true
+}
+```
+
+### Render a specific large element
+
+Combine `selector` with jumbo to capture one giant element on a page.
+
+```json
+{
+  "html": "<html>... lots of content ...<div id='poster' style='width:16000px;height:16000px;'>...</div></html>",
+  "selector": "#poster",
+  "jumbo_max_width": 16000,
+  "jumbo_max_height": 16000
+}
+```
+
+### cURL
+
+```bash
+curl -X POST https://hcti.io/v1/image \
+  -u 'user-id:api-key' \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "url": "https://example.com",
+        "jumbo_max_width": 12000,
+        "jumbo_max_height": 8100,
+        "full_screen": true
+      }'
+```
+
+<hr>
+
+## Troubleshooting
+
+### `jumbo_max_width must be present when jumbo_max_height is specified.`
+
+Both params are required together. Add the missing one.
+
+### `jumbo_max_height or jumbo_max_width should be greater than 8000`
+
+At least one dimension must be `> 8000`. If both are `<= 8000`, drop the jumbo params and use a normal render — it will be cheaper and faster.
+
+### `total jumbo pixel area cannot be greater than 400,000,000.`
+
+`jumbo_max_width * jumbo_max_height` exceeds the 400M area cap. Reduce one or both dimensions.
+
+### `cannot set pdf_options and jumbo options together`
+
+Jumbo is image-only (PNG / JPG / WebP). Remove `pdf_options` if you want a jumbo render.
+
+### My image came back smaller than `jumbo_max_width` x `jumbo_max_height`
+
+Those parameters are **maximums**. If your content is naturally smaller, the output will be smaller too. If your content is larger, the renderer downscales to fit while preserving aspect ratio — so the output matches one dimension exactly and is shorter on the other axis.
+
+### My large image is blurry (and I'm not using jumbo)
+
+When a render naturally exceeds ~8000px and `jumbo_max_width` / `jumbo_max_height` are not set, the API scales the image down to fit Chrome's limit. The result is a single-resolution image that no longer matches your `device_scale`, which usually looks blurry — especially text and thin lines.
+
+Fix: set `jumbo_max_width` and `jumbo_max_height` to the size you actually want. The renderer will tile and stitch instead of downscaling, and your `device_scale` will be preserved.
+
+### Why did this cost N renders?
+
+See [Billing](#billing). The render count is `ceil(width / 8000) * ceil(height / 8000)` based on the **final output size**, plus any `ms_delay` cost. The dashboard usage view shows the per-image render count.
+
+{% include code_footer.md version=1 %}

--- a/guides/advanced/jumbo-images.md
+++ b/guides/advanced/jumbo-images.md
@@ -37,7 +37,7 @@ The big win is **quality**. Jumbo lets you produce huge images **without losing 
 - Each tile is rendered natively in Chrome at full resolution, then stitched. There's no resampling or post-render shrinking.
 - Crisp text, vector edges, and 1px borders that would normally turn fuzzy on huge canvases stay clean.
 
-{% include hint.md title="Without jumbo, large images get downscaled" text="If your output would naturally exceed ~8000px and you **don't** set the jumbo params, the API automatically scales the image down to fit Chrome's limit and avoid duplication issues. That manifests as a **blurry, lower-resolution image** — text gets soft, fine lines smear, and high `device_scale` values stop helping. If your render is anywhere near 8000px on either side, set `jumbo_max_width` and `jumbo_max_height` to keep it sharp." %}
+{% include hint.md title="Without jumbo, large images get downscaled" text="If your output would naturally exceed ~8000px and you **don't** set the jumbo params, the API automatically scales the image down to fit Chrome's limit and avoid duplication issues. <br/> This manifests as a **blurry, lower-resolution image** — text gets soft, fine lines smear, and high `device_scale` values stop helping. <br/> If your render is anywhere near 8000px on either side, set `jumbo_max_width` and `jumbo_max_height` to keep it sharp." %}
 
 ### When to use it
 
@@ -75,22 +75,9 @@ When you pass `jumbo_max_width` and `jumbo_max_height`, the renderer:
 5. Renders each tile separately in Chrome. No scrolling, no need to worry about sticky elements.
 6. Stitches the tiles back into a single image and uploads the result.
 
-```mermaid
-flowchart LR
-    Request[Request with jumbo_max] --> Measure[Measure natural size]
-    Measure --> Fits{Fits in max?}
-    Fits -->|Yes| FullScale[Render at full scale]
-    Fits -->|No| Downscale[Downscale, preserve aspect ratio]
-    FullScale --> Split[Split into 8000x8000 tiles]
-    Downscale --> Split
-    Split --> RenderTiles[Render each tile]
-    RenderTiles --> Stitch[Stitch tiles together]
-    Stitch --> Upload[Upload final image]
-```
-
 The result is a single large screenshot.
 
-{% include hint.md title="Jumbo is measured AFTER device_scale is applied." text="If you expect your final image to be 5000x2000 and you want a crisp retina image, you should set your jumbo max to at least 10,000x4,000." %}
+{% include hint.md title="Jumbo is measured after device_scale is applied." text="If you expect your final image to be `5,000` x `2,000` and you want a crisp retina image, you should set your jumbo max to at least `10,000` x `4,000`." %}
 
 <hr>
 
@@ -125,14 +112,15 @@ When used with `ms_delay` the [standard `ms_delay` multiple](/parameters/ms_dela
 
 ### Examples
 
-| Jumbo size | `ms_delay` | Total Tiles | Renders billed |
-|------------|-----------|------|---------------|
-| `8,001 x 8,001` | 0 | 4 | 5 |
-| `12,000 x 4,000` | 0 | 2 | 3 |
-| `16,000 x 1,000` | `6000` | 2 | 6 |
-| `24,000 x 16,000` | 0 | 6 | 7 |
-| `80,000 x 5,000` | 0 | 10 | 11 |
-| `16,000 x 16,000` | `7000` | 4 | 6 |
+| Jumbo size        | `ms_delay` | Total Tiles | Renders billed |
+|:------------------|:-----------|:-----------:|:--------------:|
+| `8,001 x 8,001`   |            | 4           | 5              |
+| `12,000 x 4,000`  |            | 2           | 3              |
+| `16,000 x 1,000`  | `6000`     | 2           | 4              |
+| `24,000 x 16,000` |            | 6           | 7              |
+| `80,000 x 5,000`  |            | 10          | 11             |
+| `16,000 x 16,000` | `7000`     | 4           | 6              |
+
 
 
 <hr>

--- a/guides/advanced/jumbo-images.md
+++ b/guides/advanced/jumbo-images.md
@@ -27,7 +27,7 @@ Render large screenshots without reducing quality by splitting and stitching til
 
 Normal images are limited to 8000 x 8000 pixels. If your image scales beyond this, we automatically scale it down by default.
 
-Jumbo images allow you to scale beyond this. When you set `jumbo_max_width` and `jumbo_max_height`, the API renders lets you generate images up to **80,000 pixels** on a side.
+Jumbo images allow you to scale beyond this. When you set `jumbo_max_width` and `jumbo_max_height`, the API lets you generate images up to **80,000 pixels** on a side.
 
 ### Why jumbo matters
 

--- a/guides/advanced/jumbo-images.md
+++ b/guides/advanced/jumbo-images.md
@@ -47,7 +47,7 @@ The big win is **quality**. Jumbo lets you produce huge images **without losing 
 - Retina (`device_scale: 2` or `3`) renders of medium-sized pages where `width * device_scale` would already cross 8000px.
 - Any HTML or URL screenshot where the natural output exceeds ~8000px.
 
-Jumbo works with both `html`/`css` and `url` requests. You can apply jumbo params on Templates as well.
+Jumbo works with both `html`/`css` and `url` requests. You can apply jumbo params on [Templates](/getting-started/templates) as well.
 
 <hr>
 

--- a/guides/advanced/jumbo-images.md
+++ b/guides/advanced/jumbo-images.md
@@ -6,14 +6,14 @@ parent: Advanced
 grand_parent: Guides
 nav_order: 6
 description: >-
-  Render images larger than 8000px by splitting into tiles and stitching them together. Includes parameter limits and billing details.
+  Render large images without reducing quality by splitting into tiles and stitching them together.
 ---
 
 # Jumbo Images
 {: .no_toc }
 {: .fs-9 }
 
-Render images larger than the standard ~8000px limit by splitting and stitching tiles.
+Render large screenshots without reducing quality by splitting and stitching tiles.
 {: .fs-6 .fw-300 }
 
 <hr>
@@ -25,7 +25,7 @@ Render images larger than the standard ~8000px limit by splitting and stitching 
 
 ## What are jumbo images?
 
-Standard renders are capped at roughly **8000 pixels** on each side. That's a Chrome rendering limit, not an API one — once you cross it, the browser starts dropping content or refusing to paint.
+Rendering really tall or wide html with Puppeteer has issues around <a href="https://github.com/puppeteer/puppeteer/issues/1576" target="_blank">8000px</a> where your content may start repeating or overlapping. Most images don't reach these extremes, and when they do - we'll scale down your image to fit and prevent this behavior.
 
 Jumbo images get around this. When you set `jumbo_max_width` and `jumbo_max_height`, the API renders your output in **8000 x 8000 tiles** and stitches them back into a single image. This lets you generate images up to **80,000 pixels** on a side.
 
@@ -33,11 +33,11 @@ Jumbo images get around this. When you set `jumbo_max_width` and `jumbo_max_heig
 
 The big win is **quality**. Jumbo lets you produce huge images **without losing sharpness**:
 
-- Your `device_scale` is preserved end-to-end. A `2x` retina render stays `2x` — even at 50,000 pixels wide.
+- Your `device_scale` is preserved end-to-end. A `2x` retina render stays `2x` — even at 40,000 pixels wide.
 - Each tile is rendered natively in Chrome at full resolution, then stitched. There's no resampling or post-render shrinking.
 - Crisp text, vector edges, and 1px borders that would normally turn fuzzy on huge canvases stay clean.
 
-{% include hint.md title="Without jumbo, large images get downscaled" text="If your output would naturally exceed ~8000px and you **don't** set the jumbo params, the API automatically scales the image down to fit Chrome's limit. That usually shows up as a **blurry, lower-resolution image** — text gets soft, fine lines smear, and high `device_scale` values stop helping. If your render is anywhere near 8000px on either side, set `jumbo_max_width` and `jumbo_max_height` to keep it sharp." %}
+{% include hint.md title="Without jumbo, large images get downscaled" text="If your output would naturally exceed ~8000px and you **don't** set the jumbo params, the API automatically scales the image down to fit Chrome's limit and avoid duplication issues. That manifests as a **blurry, lower-resolution image** — text gets soft, fine lines smear, and high `device_scale` values stop helping. If your render is anywhere near 8000px on either side, set `jumbo_max_width` and `jumbo_max_height` to keep it sharp." %}
 
 ### When to use it
 
@@ -47,7 +47,7 @@ The big win is **quality**. Jumbo lets you produce huge images **without losing 
 - Retina (`device_scale: 2` or `3`) renders of medium-sized pages where `width * device_scale` would already cross 8000px.
 - Any HTML or URL screenshot where the natural output exceeds ~8000px.
 
-Jumbo works with both `html`/`css` and `url` requests.
+Jumbo works with both `html`/`css` and `url` requests. You can apply jumbo params on Templates as well.
 
 <hr>
 
@@ -72,7 +72,7 @@ When you pass `jumbo_max_width` and `jumbo_max_height`, the renderer:
 2. If that natural size fits inside `jumbo_max_width` x `jumbo_max_height`, it renders at full resolution.
 3. If it doesn't fit, it picks the largest scale that **preserves the aspect ratio** and stays inside both maxes.
 4. Splits the output into **8000 x 8000 tiles**.
-5. Renders each tile separately in Chrome.
+5. Renders each tile separately in Chrome. No scrolling, no need to worry about sticky elements.
 6. Stitches the tiles back into a single image and uploads the result.
 
 ```mermaid
@@ -88,7 +88,9 @@ flowchart LR
     Stitch --> Upload[Upload final image]
 ```
 
-The result is a single image — you don't need to do any stitching on your end.
+The result is a single large screenshot.
+
+{% include hint.md title="Jumbo is measured AFTER device_scale is applied." text="If you expect your final image to be 5000x2000 and you want a crisp retina image, you should set your jumbo max to at least 10,000x4,000." %}
 
 <hr>
 
@@ -100,7 +102,6 @@ The result is a single image — you don't need to do any stitching on your end.
 | Min value per dimension | `1` pixel |
 | At least one dimension must exceed | `8,000` pixels |
 | Max total area (`width * height`) | `400,000,000` pixels |
-| Both parameters must be set | Yes — sending one alone returns `400` |
 | Compatible with `pdf_options` | No — jumbo is image-only |
 
 The "at least one dimension must exceed 8,000" rule exists because anything smaller fits in a single tile and should use a normal render instead.
@@ -116,32 +117,23 @@ The 400-million-pixel area cap means you can't max out both dimensions at once. 
 
 ## Billing
 
-Jumbo images consume **one render per tile**, deducted from your monthly quota.
+Jumbo images consume one additional render per tile.
 
-The number of tiles is calculated from the **final output size** (after any aspect-ratio downscaling):
+The number of tiles is calculated from the **maximum specified size**.
 
-```
-tiles = ceil(output_width / 8000) * ceil(output_height / 8000)
-```
-
-If you also use `ms_delay`, the standard delay cost is added on top of the tile count:
-
-```
-total_renders = tiles + ceil(ms_delay / 5000)   # when ms_delay > 0
-```
+When used with `ms_delay` the [standard `ms_delay` multiple](/parameters/ms_delay#credit-usage) is only applied to the base image and not the additional tile credits.
 
 ### Examples
 
-| Output size | `ms_delay` | Renders billed |
-|:------------|:-----------|:---------------|
-| `8,001 x 8,001` | 0 | 4 |
-| `12,000 x 8,100` | 0 | 2 |
-| `16,000 x 16,000` | 0 | 4 |
-| `24,000 x 16,000` | 0 | 6 |
-| `80,000 x 5,000` | 0 | 10 |
-| `16,000 x 16,000` | `7000` | 6 (4 tiles + 2 delay) |
+| Jumbo size | `ms_delay` | Total Tiles | Renders billed |
+|------------|-----------|------|---------------|
+| `8,001 x 8,001` | 0 | 4 | 5 |
+| `12,000 x 4,000` | 0 | 2 | 3 |
+| `16,000 x 1,000` | `6000` | 2 | 6 |
+| `24,000 x 16,000` | 0 | 6 | 7 |
+| `80,000 x 5,000` | 0 | 10 | 11 |
+| `16,000 x 16,000` | `7000` | 4 | 6 |
 
-{% include hint.md title="Tip" text="Set `jumbo_max_width` and `jumbo_max_height` only as large as you actually need. The render count grows quickly — doubling both dimensions roughly quadruples the cost." %}
 
 <hr>
 
@@ -151,9 +143,10 @@ total_renders = tiles + ceil(ms_delay / 5000)   # when ms_delay > 0
 
 ```json
 {
-  "html": "<div style='width:12000px;height:8100px;background:linear-gradient(45deg,#4f46e5,#ec4899);'></div>",
+  "html": "<div id='big-div' style='width:12000px;height:8100px;background:linear-gradient(45deg,#4f46e5,#ec4899);'></div>",
   "jumbo_max_width": 12000,
-  "jumbo_max_height": 8100
+  "jumbo_max_height": 8100,
+  "selector": "#big-div"
 }
 ```
 
@@ -174,10 +167,11 @@ Combine `selector` with jumbo to capture one giant element on a page.
 
 ```json
 {
-  "html": "<html>... lots of content ...<div id='poster' style='width:16000px;height:16000px;'>...</div></html>",
+  "html": "<html>... lots of content ...<div id='poster' style='width:5000px;height:9000px;'>...</div></html>",
   "selector": "#poster",
-  "jumbo_max_width": 16000,
-  "jumbo_max_height": 16000
+  "jumbo_max_width": 10000,
+  "jumbo_max_height": 18000,
+  "device_scale": 2
 }
 ```
 
@@ -219,14 +213,22 @@ Jumbo is image-only (PNG / JPG / WebP). Remove `pdf_options` if you want a jumbo
 
 Those parameters are **maximums**. If your content is naturally smaller, the output will be smaller too. If your content is larger, the renderer downscales to fit while preserving aspect ratio — so the output matches one dimension exactly and is shorter on the other axis.
 
-### My large image is blurry (and I'm not using jumbo)
+### My large image is blurry (and I'm not using jumbo parameters)
 
 When a render naturally exceeds ~8000px and `jumbo_max_width` / `jumbo_max_height` are not set, the API scales the image down to fit Chrome's limit. The result is a single-resolution image that no longer matches your `device_scale`, which usually looks blurry — especially text and thin lines.
 
 Fix: set `jumbo_max_width` and `jumbo_max_height` to the size you actually want. The renderer will tile and stitch instead of downscaling, and your `device_scale` will be preserved.
 
+#### For example: 
+
+If your final image is 10,000 px tall, the effective device_scale will be 0.8 to fit it within the 8000px boundary. If you're expecting a readable, sharp image - you need jumbo.
+
 ### Why did this cost N renders?
 
-See [Billing](#billing). The render count is `ceil(width / 8000) * ceil(height / 8000)` based on the **final output size**, plus any `ms_delay` cost. The dashboard usage view shows the per-image render count.
+See [Billing](#billing). The render count is `1 + ceil(width / 8000) * ceil(height / 8000)` based on the **maximum output size**, plus any [`ms_delay` cost](/parameters/ms_delay#credit-usage). The dashboard usage view shows the per-image render count.
+
+### Why does jumbo cost more?
+
+Jumbo images require significantly more resources than a standard image to render, stitch and store.
 
 {% include code_footer.md version=1 %}

--- a/guides/advanced/jumbo-images.md
+++ b/guides/advanced/jumbo-images.md
@@ -25,9 +25,9 @@ Render large screenshots without reducing quality by splitting and stitching til
 
 ## What are jumbo images?
 
-Normal images are limited to 8000 x 8000 pixels. If your image scales beyond this, we automatically scale it down by default.
+Rendering really tall or wide html (~ 8,000px) causes quality to degrade. Most images don't reach these extremes, and when they do - we'll scale down your image to fit and prevent unwanted behavior.
 
-Jumbo images allow you to scale beyond this. When you set `jumbo_max_width` and `jumbo_max_height`, the API lets you generate images up to **80,000 pixels** on a side.
+Jumbo images allow you to scale beyond this without sacrificing quality. When you set `jumbo_max_width` and `jumbo_max_height`, the API lets you generate images up to **80,000 pixels** on a side.
 
 ### Why jumbo matters
 

--- a/guides/advanced/jumbo-images.md
+++ b/guides/advanced/jumbo-images.md
@@ -25,7 +25,7 @@ Render large screenshots without reducing quality by splitting and stitching til
 
 ## What are jumbo images?
 
-Rendering really tall or wide html with Puppeteer has issues around <a href="https://github.com/puppeteer/puppeteer/issues/1576" target="_blank">8000px</a> where your content may start repeating or overlapping. Most images don't reach these extremes, and when they do - we'll scale down your image to fit and prevent this behavior.
+Normal images are limited to 8000 x 8000 pixels. If your image scales beyond this, we automatically scale it down by default.
 
 Jumbo images allow you to scale beyond this. When you set `jumbo_max_width` and `jumbo_max_height`, the API renders lets you generate images up to **80,000 pixels** on a side.
 

--- a/guides/index.md
+++ b/guides/index.md
@@ -15,7 +15,7 @@ description: >-
 In-depth guides for common tasks and advanced features.
 {: .fs-4 .fw-300 }
 
-[Live demo](https://htmlcsstoimage.com/demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Live demo](https://htmlcsstoimage.com/#demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [Get an API Key](https://htmlcsstoimage.com){: .btn .fs-5 .mb-4 .mb-md-0 }
 
 <hr>

--- a/guides/workflows/email-to-images.md
+++ b/guides/workflows/email-to-images.md
@@ -15,7 +15,7 @@ description: >-
 Generate images of full webpages and emails with HTML/CSS to Image. Renders exactly like Google Chrome.
 {: .fs-4 .fw-300 }
 
-[Live demo](https://htmlcsstoimage.com/demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 target="_blank" }
+[Live demo](https://htmlcsstoimage.com/#demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 target="_blank" }
 [Get an API Key](https://htmlcsstoimage.com){: .btn .fs-5 .mb-4 .mb-md-0 target="_blank" }
 <hr>
 
@@ -38,7 +38,7 @@ For more details on how the API works, see [Creating an image](/getting-started/
   </div>
 </div>
 
-[Try it yourself](https://htmlcsstoimage.com/demo){: .btn .btn-green .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Try it yourself](https://htmlcsstoimage.com/#demo){: .btn .btn-green .fs-5 .mb-4 .mb-md-0 .mr-2 }
 
 <hr>
 

--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ nav_order: 1
 Your search for pixel perfect image generation ends here.
 {: .fs-6 .fw-300 }
 
-[Live demo](https://htmlcsstoimage.com/demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Live demo](https://htmlcsstoimage.com/#demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [Get an API Key](https://htmlcsstoimage.com){: .btn .fs-5 .mb-4 .mb-md-0 }
 <hr>
 

--- a/integrations/index.md
+++ b/integrations/index.md
@@ -15,7 +15,7 @@ description: >-
 Connect the HTML/CSS to Image API to thousands of other services.
 {: .fs-4 .fw-300 }
 
-[Live demo](https://htmlcsstoimage.com/demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Live demo](https://htmlcsstoimage.com/#demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [Get an API Key](https://htmlcsstoimage.com){: .btn .fs-5 .mb-4 .mb-md-0 }
 
 <hr>

--- a/llms.txt
+++ b/llms.txt
@@ -49,6 +49,8 @@ curl -X POST https://hcti.io/v1/image \
 | `viewport_height` | Browser viewport height |
 | `selector` | CSS selector to capture specific element |
 | `ms_delay` | Milliseconds to wait before capture |
+| `jumbo_max_width` | Max output width for jumbo renders (up to 80,000px). Must be set with `jumbo_max_height`. |
+| `jumbo_max_height` | Max output height for jumbo renders (up to 80,000px). Must be set with `jumbo_max_width`. |
 
 ## Documentation
 
@@ -58,6 +60,7 @@ curl -X POST https://hcti.io/v1/image \
 - **MCP Server:** https://docs.htmlcsstoimage.com/integrations/mcp/
 - **TypeScript Client (npm):** https://docs.htmlcsstoimage.com/example-code/typescript/
 - **HTTP Proxies:** https://docs.htmlcsstoimage.com/guides/advanced/proxies/
+- **Jumbo Images:** https://docs.htmlcsstoimage.com/guides/advanced/jumbo-images/
 - **FAQ:** https://docs.htmlcsstoimage.com/faq/
 
 ## Integrations

--- a/parameters/google_fonts.md
+++ b/parameters/google_fonts.md
@@ -153,6 +153,6 @@ If you need to use fonts not available on Google Fonts:
 2. Convert your font to base64 and include it directly in your CSS
 3. Host the font files yourself and reference them via URL
 
-[Try it yourself](https://htmlcsstoimage.com/demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Try it yourself](https://htmlcsstoimage.com/#demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 
 {% include code_footer.md version=1 %} 

--- a/parameters/index.md
+++ b/parameters/index.md
@@ -15,7 +15,7 @@ description: >-
 Detailed information on all the available parameters for the API.
 {: .fs-4 .fw-300 }
 
-### Parameters
+## Parameters
 
 The create image endpoint accepts the following parameters. Accepted as either `json` or `formdata`.
 
@@ -29,7 +29,7 @@ The create image endpoint accepts the following parameters. Accepted as either `
 
 <hr>
 
-### Additional parameters
+## Additional parameters
 
 Optional parameters for greater control over your image.
 
@@ -37,5 +37,5 @@ Optional parameters for greater control over your image.
 
 <hr>
 
-[Live demo](https://htmlcsstoimage.com/demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Live demo](https://htmlcsstoimage.com/#demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [Get an API Key](https://htmlcsstoimage.com){: .btn .fs-5 .mb-4 .mb-md-0 }

--- a/use-cases/index.md
+++ b/use-cases/index.md
@@ -14,7 +14,7 @@ description: >-
 See how developers are using HTML/CSS to Image in production.
 {: .fs-4 .fw-300 }
 
-[Live demo](https://htmlcsstoimage.com/demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Live demo](https://htmlcsstoimage.com/#demo){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [Get an API Key](https://htmlcsstoimage.com){: .btn .fs-5 .mb-4 .mb-md-0 }
 
 <hr>


### PR DESCRIPTION
- Adds docs for jumbo image parameters.
- fixes `/demo` link to be `/#demo` because that's what it redirects to anyhow.
- tweak css on large screens to prevent resizing outer container 